### PR TITLE
fix: sanitize Mermaid markdown wrappers before returning diagram supplements

### DIFF
--- a/backend/backend/src/services/llm.py
+++ b/backend/backend/src/services/llm.py
@@ -935,6 +935,20 @@ async def generate_question_supplements_with_llm(
             trimmed.pop()
         return "\n".join(trimmed).strip()
 
+    def _sanitize_mermaid(content: str) -> str:
+        c = content.strip()
+        was_wrapped = False
+        if c.startswith("```mermaid"):
+            c = c[len("```mermaid"):].strip()
+            was_wrapped = True
+        if c.endswith("```"):
+            c = c[:-3].strip()
+        if was_wrapped:
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.info(f"[Mermaid Sanitizer] Before:\n{content}\nAfter:\n{c}")
+        return c
+
     sanitized: list[LLMSupplementItem] = []
     if result:
         for item in result.items:
@@ -945,6 +959,10 @@ async def generate_question_supplements_with_llm(
             if supplement_type not in {"code", "diagram"}:
                 continue
             fmt = (item.format or "").strip() or ("mermaid" if supplement_type == "diagram" else None)
+            
+            if supplement_type == "diagram" and fmt == "mermaid":
+                snippet = _sanitize_mermaid(snippet)
+                
             sanitized.append(
                 LLMSupplementItem(
                     questionId=item.questionId,


### PR DESCRIPTION
## Summary

Fixes an issue where Mermaid diagram supplements could be returned with Markdown code fences (`mermaid ... `), causing the frontend Mermaid renderer to fail and display a blank diagram.

## Root Cause

The LLM occasionally generates Mermaid content wrapped in Markdown code blocks. The backend was passing this content through unchanged, while the frontend renderer expects raw Mermaid syntax.

## Changes

* Added Mermaid content sanitization in `src/services/llm.py`
* Strip surrounding `mermaid and ` wrappers before persisting/returning diagram content
* Leave already-clean Mermaid content unchanged
* Added logging to aid troubleshooting and verification

## Scope

* Backend only
* No frontend changes
* Minimal, isolated fix

## Validation

* Verified backend startup locally
* Verified database connection initialization
* Confirmed sanitization is applied only to Mermaid diagram supplements
* Existing clean Mermaid content remains unaffected

## Expected Result

Diagram supplements now consistently return pure Mermaid syntax, allowing the frontend Mermaid renderer to render diagrams correctly without blank states.
