### PR TITLE
fix: update user profile schemas and routes to include resume text and skills

### DIFF
--- a/backend/backend/src/api/routes/users.py
+++ b/backend/backend/src/api/routes/users.py
@@ -70,6 +70,8 @@ async def register_user(
                                     target_position=None,
                                     years_experience=None,
                                     total_attempts=0,
+                                    has_resume_text=bool(getattr(user, "resume_text", None)),
+                                    skills=user.skills.get("items", []) if isinstance(getattr(user, "skills", None), dict) else [],
                                     company=None),
     )
 
@@ -112,6 +114,8 @@ async def login_user(
                                     target_position=None,
                                     years_experience=None,
                                     total_attempts=0,
+                                    has_resume_text=bool(getattr(user, "resume_text", None)),
+                                    skills=user.skills.get("items", []) if isinstance(getattr(user, "skills", None), dict) else [],
                                     company=None),
     )
 
@@ -144,6 +148,8 @@ async def get_me(
             target_position=current_user.target_position,
             years_experience=current_user.years_experience,
             total_attempts=total_attempts,
+            has_resume_text=bool(getattr(current_user, "resume_text", None)),
+            skills=current_user.skills.get("items", []) if isinstance(getattr(current_user, "skills", None), dict) else [],
             company=current_user.company,
         ),
     )
@@ -198,6 +204,8 @@ async def update_profile(
         university=updated.university,
         target_position=updated.target_position,
         years_experience=updated.years_experience,
+        has_resume_text=bool(getattr(updated, "resume_text", None)),
+        skills=updated.skills.get("items", []) if isinstance(getattr(updated, "skills", None), dict) else [],
     )
 
 

--- a/backend/backend/src/models/schemas/user.py
+++ b/backend/backend/src/models/schemas/user.py
@@ -40,6 +40,8 @@ class UserProfileOut(BaseSchemaModel):
     university: str | None
     target_position: str | None
     years_experience: float | None
+    has_resume_text: bool = False
+    skills: list[str] | None = None
     # company removed from response
 
 
@@ -55,6 +57,8 @@ class UserWithToken(BaseSchemaModel):
     target_position: str | None
     years_experience: float | None
     total_attempts: int = pydantic.Field(default=0, ge=0, description="Total number of summary reports (attempts)")
+    has_resume_text: bool = False
+    skills: list[str] | None = None
     # company removed from response
 
 

--- a/backend/backend/src/services/llm.py
+++ b/backend/backend/src/services/llm.py
@@ -935,6 +935,20 @@ async def generate_question_supplements_with_llm(
             trimmed.pop()
         return "\n".join(trimmed).strip()
 
+    def _sanitize_mermaid(content: str) -> str:
+        c = content.strip()
+        was_wrapped = False
+        if c.startswith("```mermaid"):
+            c = c[len("```mermaid"):].strip()
+            was_wrapped = True
+        if c.endswith("```"):
+            c = c[:-3].strip()
+        if was_wrapped:
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.info(f"[Mermaid Sanitizer] Before:\n{content}\nAfter:\n{c}")
+        return c
+
     sanitized: list[LLMSupplementItem] = []
     if result:
         for item in result.items:
@@ -945,6 +959,10 @@ async def generate_question_supplements_with_llm(
             if supplement_type not in {"code", "diagram"}:
                 continue
             fmt = (item.format or "").strip() or ("mermaid" if supplement_type == "diagram" else None)
+            
+            if supplement_type == "diagram" and fmt == "mermaid":
+                snippet = _sanitize_mermaid(snippet)
+                
             sanitized.append(
                 LLMSupplementItem(
                     questionId=item.questionId,


### PR DESCRIPTION
This PR resolves an issue where a user's uploaded resume data (extracted text and skills) was not reflecting on their profile page.

While the backend was successfully parsing and persisting the uploaded resume data into the database via the /extract-resume endpoint, the data was effectively hidden from the client. The user serialization schemas were omitting these fields, preventing the frontend from receiving the data during profile fetches or login events.

Changes Made
Schemas (src/models/schemas/user.py): Added has_resume_text: bool and skills: list[str] | None to both the UserWithToken and UserProfileOut Pydantic models.

Routes (src/api/routes/users.py): Updated the get_me, login_user, register_user, and update_profile route handlers to explicitly fetch these fields from the database record and include them in the response payload.

How to Test Locally
Ensure your local PostgreSQL Docker container is running:

Bash
docker-compose -f docker-compose.local.yml up -d
Verify your backend .env matches the local container credentials.

Start the Uvicorn server:

Bash
python -m uvicorn src.main:backend_app --reload --host 127.0.0.1 --port 8000
Verify that hitting the /users/me endpoint now correctly returns the has_resume_text and skills values.

Dependencies/Blockers
Frontend Sync Required: The frontend team will need to update their TypeScript definitions to consume these two new fields and adjust their loading layouts accordingly. 