### PR TITLE
Fix UI flags and enforce strict deterministic project scoring

### DIFF
--- a/backend/backend/src/services/ai_resume/scoring/ats_calculator.py
+++ b/backend/backend/src/services/ai_resume/scoring/ats_calculator.py
@@ -121,7 +121,7 @@ class ATSCalculator:
             portfolio_working = portfolio_node.get("working", False)
 
         # do not flag a standalone custom portfolio as true.
-        if link_report.get("track") == "engineering" and not analysis.get("portfolio"):
+        if link_report.get("track") == "engineering" and not analysis.get("projects"):
             # If no independent domain URL was categorized outside git/linkedin by your flat_map, force false
             has_portfolio = False
             portfolio_working = False

--- a/backend/backend/src/services/ai_resume/scoring/ats_engine.py
+++ b/backend/backend/src/services/ai_resume/scoring/ats_engine.py
@@ -76,18 +76,7 @@ class ATSEngine:
             raw_resume_text=raw_resume_text,
             project_report=project_report
         )
-        # FIXED: Text-based fail-safe checks for link presence to capture plain-text handlers
-        text_lower = raw_resume_text.lower()
-        
-        if "github" in text_lower or "github.com" in text_lower:
-            master_report["hygieneCheck"]["hasGithub"] = True
-            # If links are clearly present in project bullet points, enforce working status fallback
-            if "link:" in text_lower or "http" in text_lower:
-                master_report["hygieneCheck"]["githubWorking"] = True
 
-        if "linkedin" in text_lower or "linkedin.com" in text_lower:
-            master_report["hygieneCheck"]["hasLinkedIn"] = True
-            master_report["hygieneCheck"]["linkedInWorking"] = True
 
         # Matches patterns like: +91 9618211626, 9912081886, +91-98765-43210, +1 (555) 019-2834
         phone_regex = re.compile(
@@ -96,6 +85,7 @@ class ATSEngine:
         
         # Scrape and audit raw resume text buffer
         raw_text_strip = raw_resume_text.strip()
+        text_lower = raw_resume_text.lower()
         
         # Execute structural regex search loop
         has_phone = bool(phone_regex.search(raw_text_strip))

--- a/backend/backend/src/services/ai_resume/scoring/project_scorer.py
+++ b/backend/backend/src/services/ai_resume/scoring/project_scorer.py
@@ -51,18 +51,12 @@ class ProjectScorer:
             #     has_deployment = True
             # deploy_points = 10 if has_deployment else 0
             # 2. GitHub Code Repository Check (+10)
-            has_github = "github.com" in url_text or "github.com" in body_text or "gitlab.com" in url_text or "github" in body_text
-            # If they have anchor link text indicators next to the code stack, treat it as present
-            if "link:" in body_text and any(tech in body_text for tech in ["react", "node", "express", "python"]):
-                has_github = True
+            has_github = "github.com" in url_text or "gitlab.com" in url_text
             gh_points = 10 if has_github else 0
 
             # 3. Live Cloud Deployment URL Check (+10)
-            has_deployment = any(host in url_text or host in body_text for host in ["vercel", "netlify", "render.com", "heroku", "aws", "github.io"])
-            if direct_url and "github.com" not in url_text:
-                has_deployment = True
-            # FIXED FALLBACK: If the text states a deployment link keyword indicator like "link: here", do not penalize it with a 0
-            if "link:" in body_text or "url:" in body_text or "demo" in body_text:
+            has_deployment = any(host in url_text for host in ["vercel", "netlify", "render.com", "heroku", "aws", "github.io"])
+            if direct_url and "github.com" not in url_text and "gitlab.com" not in url_text:
                 has_deployment = True
             deploy_points = 10 if has_deployment else 0
 


### PR DESCRIPTION
This PR fixes several critical bugs in the deterministic ATS scoring engine where the frontend UI flags (Green Ticks / Red Crosses) were heavily mismatching the actual mathematical scores awarded by the SmartLinkValidator. It also enforces strict link validation by removing text-based hacks.

What was the Problem?
False Negative (Red Cross) for Engineering Portfolios: Even if an engineer provided a valid portfolio, the UI automatically overwrote the has_portfolio flag to False. This was caused by a dictionary key mismatch where the backend saved the portfolio under the key "projects", but the safety check was looking for "portfolio".
False Positive (Green Tick) for GitHub Links: The system was incorrectly displaying a Green Tick for GitHub even if the candidate had a broken link or just typed the word "GitHub: " with an empty space. This was caused by a fail-safe hack in ats_engine.py that forced the flag to True if it simply found the word "github" in the raw text.
Fake Project Deployment Points: project_scorer.py was awarding 10 deployment points if the user simply typed words like "vercel" or "demo" in the project description, without requiring an actual functional URL string.
What We Solved
Fixed Portfolio Sync: Updated ats_calculator.py to check for "projects" instead of "portfolio" for the engineering track. Engineers with valid portfolios will now correctly receive a Green Tick on the frontend.
Strict GitHub Validation: Deleted the if "github" in text_lower hack in ats_engine.py. The UI flag for GitHub will now strictly rely on the output of the real-time SmartLinkValidator.
Strict Project Scoring: Modified project_scorer.py to only award deployment points and repository points if an actual URL (github.com, gitlab.com, etc.) is provided, ignoring generic raw-text matches.
Code Changes at a Glance
1. ats_calculator.py

python
# Changed safety check key to match link_scorer output
if link_report.get("track") == "engineering" and not analysis.get("projects"):
    has_portfolio = False
2. ats_engine.py

Removed the following text-override block:
python
- if "github" in text_lower or "github.com" in text_lower:
-     master_report["hygieneCheck"]["hasGithub"] = True
3. project_scorer.py

Replaced the loose regex scans with strict URL enforcement:
python
# Before
has_deployment = any(host in url_text or host in body_text for host in ["vercel", "demo"])
# After
has_deployment = any(host in url_text for host in ["vercel", "netlify", "render.com", "heroku", "aws", "github.io"])