### PR TITLE
feat: implement sequential batched question generation

### DIFF
--- a/backend/backend/src/api/routes/interviews_v2.py
+++ b/backend/backend/src/api/routes/interviews_v2.py
@@ -360,9 +360,21 @@ async def generate_questions_v2(
             admin_questions = await job_profile_repo.get_job_profile_questions(interview.job_profile_id)
             level_questions = [q for q in admin_questions if q.level == mapped_level]
             if level_questions:
-                import random
-                random.seed(f"{current_user.id}:{interview.id}")
-                selected = random.sample(level_questions, min(len(level_questions), 5))
+                # Get the number of previous interviews the user took for this specific profile and difficulty
+                past_interview_count = await interview_repo.count_user_interviews_by_profile_and_difficulty(
+                    user_id=current_user.id,
+                    job_profile_id=interview.job_profile_id,
+                    difficulty=interview.difficulty,
+                    current_interview_id=interview.id
+                )
+                
+                # Pick 5 questions sequentially
+                start_idx = (past_interview_count * 5) % len(level_questions)
+                selected = []
+                for i in range(min(5, len(level_questions))):
+                    idx = (start_idx + i) % len(level_questions)
+                    selected.append(level_questions[idx])
+                
                 questions = [q.question_text for q in selected]
                 items = []
                 for q in selected:
@@ -595,10 +607,18 @@ async def generate_non_tech_questions_v2(
     cached = bool(existing)
 
     if not existing:
+        past_interview_count = await interview_repo.count_user_interviews_by_profile_and_difficulty(
+            user_id=current_user.id,
+            job_profile_id=job_profile.id,
+            difficulty=difficulty,
+            current_interview_id=interview.id
+        )
+
         questions_data = select_non_tech_interview_questions(
             role_name=normalized_job_name,
             company_name=job_profile.company_name,
             seed=f"{current_user.id}:{job_profile.id}:{interview.id}",
+            past_interview_count=past_interview_count,
         )
 
         if payload.use_resume and isinstance(getattr(current_user, "resume_text", None), str):

--- a/backend/backend/src/api/routes/interviews_v2.py
+++ b/backend/backend/src/api/routes/interviews_v2.py
@@ -585,6 +585,7 @@ async def generate_non_tech_questions_v2(
             user_id=current_user.id,
             track=track,
             difficulty=difficulty,
+            job_profile_id=job_profile.id,
         )
         await track_analytics_event(
             interview_repo.async_session,

--- a/backend/backend/src/repository/crud/interview.py
+++ b/backend/backend/src/repository/crud/interview.py
@@ -161,4 +161,17 @@ class InterviewCRUDRepository(BaseCRUDRepository):
         
         return result, next_cursor
 
+    async def count_user_interviews_by_profile_and_difficulty(self, user_id: int, job_profile_id: int, difficulty: str, current_interview_id: int) -> int:
+        """Counts the number of previous interviews the user has created for this profile/difficulty."""
+        stmt = (
+            sqlalchemy.select(sqlalchemy.func.count(Interview.id))
+            .where(Interview.user_id == user_id)
+            .where(Interview.job_profile_id == job_profile_id)
+            .where(Interview.difficulty == difficulty)
+            .where(Interview.id < current_interview_id)
+        )
+        query = await self.async_session.execute(statement=stmt)
+        count = query.scalar()
+        return count or 0
+
 

--- a/backend/backend/src/services/non_tech_blueprint.py
+++ b/backend/backend/src/services/non_tech_blueprint.py
@@ -188,17 +188,20 @@ def select_non_tech_interview_questions(
     role_name: str,
     company_name: str | None,
     seed: str,
+    past_interview_count: int = 0,
 ) -> list[dict[str, str]]:
     bank = build_non_tech_question_bank(role_name=role_name, company_name=company_name)
     labels = non_tech_category_labels()
 
-    randomizer = random.Random(seed)
     selected: list[dict[str, str]] = []
     for category in non_tech_category_keys():
         bucket = bank.get(category, [])
         if len(bucket) < 20:
             raise ValueError(f"Question bank for category '{category}' must contain at least 20 questions")
-        question_text = randomizer.choice(bucket)
+        
+        idx = past_interview_count % len(bucket)
+        question_text = bucket[idx]
+        
         selected.append(
             {
                 "text": question_text,


### PR DESCRIPTION

This PR replaces the previous random question generation logic with a sequential, batched selection process.

Previously, when an interview was generated, the system would pick 5 random questions from the database pool for that specific job profile and difficulty. With these changes, the system now tracks the user's interview history to provide deterministic, sequential batches (e.g., 1st interview gets Q1-5, 2nd interview gets Q6-10). This ensures a fresh, non-repetitive experience for returning users until the question pool is fully exhausted.

This logic applies to both Tech Interviews (custom Admin Job Profiles) and Non-Tech Interviews (bucketed categories).

Changes Made
src/repository/crud/interview.py: Added a new repository method count_user_interviews_by_profile_and_difficulty() to securely query how many prior interviews the user has initiated for an exact Job Profile and Difficulty level.
src/api/routes/interviews_v2.py: Updated generate_questions_v2 and generate_non_tech_questions_v2 to replace random.sample() with a modulo-based slicing algorithm that uses the user's past interview count as an offset.
src/services/non_tech_blueprint.py: Modified select_non_tech_interview_questions() to accept past_interview_count and sequentially pick the correct N-th question from each category bucket rather than picking randomly.
Edge Cases Handled Successfully
Empty/Small Pools: Safely handles difficulty levels with < 5 questions using min() constraints without throwing out-of-bounds errors.
Pool Exhaustion (Wrap Around): Uses modulo arithmetic (%) to seamlessly wrap the index back to 0. If a database has 15 questions, the user's 4th interview seamlessly restarts at Q1-5.
Uneven Batches: If a pool has 7 questions, the 2nd interview gracefully grabs Q6, Q7, and wraps around mid-batch to grab Q1, Q2, Q3 to guarantee 5 questions are returned.
