### PR TITLE
fix: load AWS credentials properly from .env in S3 client initialization

### DIFF
--- a/backend/backend/src/services/s3_service.py
+++ b/backend/backend/src/services/s3_service.py
@@ -10,9 +10,11 @@ logger = logging.getLogger(__name__)
 
 # Initialize boto3 client lazily or handle missing creds gracefully
 try:
-    # Boto3 will automatically look for AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in the environment
+    # Explicitly pass credentials from .env via config()
     s3_client = boto3.client(
         's3',
+        aws_access_key_id=config("AWS_ACCESS_KEY_ID", default=None),
+        aws_secret_access_key=config("AWS_SECRET_ACCESS_KEY", default=None),
         region_name=config("AWS_REGION", default="ap-south-1")
     )
     BUCKET_NAME = config("AWS_S3_BUCKET_NAME", default="barabari-edtech-service-staging")


### PR DESCRIPTION
This PR fixes a bug where the boto3 client was failing to authenticate (NoCredentialsError) when uploading audio to S3 in background tasks.

Changes Made:

Updated the s3_client initialization in src/services/s3_service.py to explicitly load AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY via python-decouple's config() function.
Previously, the code relied on boto3 automatically picking up system environment variables, which caused silent failures when environment variables were only present in the .env file and not fully exported to the host system.
